### PR TITLE
SimpleAsset Bug Fix and Fabric-cli updated to initialize Asset networks.

### DIFF
--- a/samples/simpleasset/tokenasset.go
+++ b/samples/simpleasset/tokenasset.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
+	// log "github.com/sirupsen/logrus"
 )
 
 type TokenAssetType struct {
@@ -172,6 +173,9 @@ func (s *SmartContract) GetBalance(ctx contractapi.TransactionContextInterface, 
 	if err != nil {
 		return -1, fmt.Errorf("failed to read owner's wallet from world state: %v", err)
 	}
+	if walletJSON == nil {
+		return -1, fmt.Errorf("owner does not have a wallet.")
+	}
 
 	var wallet TokenWallet
 	err = json.Unmarshal(walletJSON, &wallet)
@@ -194,8 +198,11 @@ func (s *SmartContract) TokenAssetsExist(ctx contractapi.TransactionContextInter
 // Helper Functions for token asset
 func addTokenAssetsHelper(ctx contractapi.TransactionContextInterface, id string, tokenAssetType string, numUnits int) error {
 	walletJSON, err := ctx.GetStub().GetState(id)
+	if err != nil {
+		return err
+	}
 	var wallet TokenWallet
-	if err == nil {
+	if walletJSON != nil {
 		err = json.Unmarshal(walletJSON, &wallet)
 		if err != nil {
 			return err
@@ -222,6 +229,9 @@ func subTokenAssetsHelper(ctx contractapi.TransactionContextInterface, id string
 	var wallet TokenWallet
 	if err != nil {
 		return err
+	}
+	if walletJSON == nil {
+		return fmt.Errorf("owner does not have a wallet.")
 	}
 
 	err = json.Unmarshal(walletJSON, &wallet)

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/asset-helper.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/asset-helper.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GluegunCommand } from 'gluegun'
+import { commandHelp } from '../../helpers/helpers'
+
+const command: GluegunCommand = {
+  name: 'asset',
+  alias: [],
+  description: 'Configure for asset networks',
+  run: async toolbox => {
+    const {
+      print,
+      parameters: { options }
+    } = toolbox
+    if (options.help || options.h) {
+      commandHelp(
+        print,
+        toolbox,
+        'fabric-cli configure asset all --target-network=network1 --type=bond',
+        'fabric-cli configure asset <subcommand>',
+        [],
+        command,
+        ['configure', 'asset']
+      )
+      return
+    }
+    print.info('Command does nothing by itself')
+  }
+}
+
+module.exports = command

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/asset/add.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/asset/add.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GluegunCommand } from 'gluegun'
+import * as path from 'path'
+import { commandHelp, addAssets, getNetworkConfig } from '../../../helpers/helpers'
+import { fabricHelper } from '../../../helpers/fabric-functions'
+
+import logger from '../../../helpers/logger'
+import * as dotenv from 'dotenv'
+dotenv.config({ path: path.resolve(__dirname, '../../../.env') })
+
+const delay = ms => new Promise(res => setTimeout(res, ms))
+
+const command: GluegunCommand = {
+  name: 'add',
+  description:
+    'Adds assets to asset network',
+  run: async toolbox => {
+    const {
+      print,
+      parameters: { options, array }
+    } = toolbox
+    if (options.help || options.h) {
+      commandHelp(
+        print,
+        toolbox,
+        'fabric-cli configure asset add --target-network=network1 --type=bond --data-file=src/data/assets.json',
+        'fabric-cli configure asset add --target-network=<network-name> --type=<bond|token --data-file=<path-to-data-file>>',
+        [
+          {
+            name: '--debug',
+            description:
+              'Shows debug logs when running. Disabled by default. To enable --debug=true'
+          },
+          {
+            name: '--target-network',
+            description:
+              'target-network network for command. <network1|network2>'
+          },
+          {
+            name: '--type',
+            description:
+              'Type of network <bond|token>'
+          },
+          {
+            name: '--data-file',
+            description:
+              'Path to data file which stores assets in json format'
+          }
+        ],
+        command,
+        ['configure', 'asset', 'add']
+      )
+      return
+    }
+
+    if (options.debug === 'true') {
+      logger.level = 'debug'
+      logger.debug('Debugging is enabled')
+    }
+    if (!options['target-network'])
+    {
+      print.error('--target-network needs to be specified')
+      return
+    }
+    if (!options['type'])
+    {
+      print.error('--type of network needs to be specified')
+      return
+    }
+    if (!options['data-file'])
+    {
+      print.error('--data-file needs to be specified')
+      return
+    }
+
+    const netConfig = getNetworkConfig(options['target-network'])
+
+    if (!netConfig.connProfilePath || !netConfig.channelName || !netConfig.chaincode) {
+      print.error(
+        `Please use a valid --target-network. No valid environment found for ${options['target-network']} `
+      )
+      return
+    }
+
+    addAssets({
+      dataFilePath: options['data-file'],
+      networkName: options['target-network'],
+      connProfilePath: netConfig.connProfilePath,
+      mspId: netConfig.mspId,
+      channelName: netConfig.channelName,
+      contractName: netConfig.chaincode,
+      ccType: options['type'],
+      logger: logger
+    })
+  }
+}
+
+module.exports = command

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/user-helper.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/user-helper.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GluegunCommand } from 'gluegun'
+import { commandHelp, validKeys } from '../helpers/helpers'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const command: GluegunCommand = {
+  name: 'user',
+  alias: ['u'],
+  description: 'User utility for fabric-network',
+  run: async toolbox => {
+    const { print } = toolbox
+    print.info('Command does nothing by itself')
+    commandHelp(print, toolbox, 'fabric-cli user add', '', [], command, [
+      'user'
+    ])
+    return
+  }
+}
+
+module.exports = command

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/user/add.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/user/add.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GluegunCommand } from 'gluegun'
+import { commandHelp, getNetworkConfig } from '../../helpers/helpers'
+import * as fs from 'fs'
+import * as path from 'path'
+import { walletSetup } from '../../helpers/fabric-functions'
+
+const command: GluegunCommand = {
+  name: 'add',
+  description: 'Register and enroll user to the fabric network',
+  run: async toolbox => {
+    const {
+      print,
+      parameters: { options, array }
+    } = toolbox
+    if (options.help || options.h) {
+      commandHelp(
+        print,
+        toolbox,
+        `fabric-cli add user --target-network=network1--id=user --secret=userpw`,
+        `fabric-cli add user --target-network=<network-name> --id=<id> --secret=<secret>`,
+        [],
+        command,
+        ['user', 'add']
+      )
+      return
+    }
+    if (!options['target-network']) {
+      print.error('--target-network is required arguement, please specify the network name here')
+    }
+    if (!options['id']) {
+      print.error('--id is required arguement, please specify the username here')
+    }
+    // if (!options['secret']) {
+    //   print.error('--secret is required arguement, please specify the password for the user here')
+    // }
+
+    const userName = options['id']
+    const userPwd = options['secret']
+    const net = getNetworkConfig(options['target-network'])
+
+    const ccpPath = path.resolve(__dirname, net.connProfilePath)
+    const ccp = JSON.parse(fs.readFileSync(ccpPath, 'utf8'))
+    console.log(net)
+
+    let wallet = walletSetup(options['target-network'],
+                    ccp,
+                    net.mspId,
+                    userName,
+                    userPwd,
+                    true
+                  )
+  }
+}
+
+module.exports = command

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/data/assets.json
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/data/assets.json
@@ -1,0 +1,16 @@
+{
+  "a03": {
+    "id": "a03",
+    "owner": "alice",
+    "issuer": "treasury",
+    "facevalue": "500",
+    "maturitydate": "01 Jan 22 00:00 MST"
+  },
+  "a04": {
+    "id": "a04",
+    "owner": "bob",
+    "issuer": "treasury",
+    "facevalue": "700",
+    "maturitydate": "01 Jul 22 00:00 MST"
+  }
+}

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/data/tokens.json
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/data/tokens.json
@@ -1,0 +1,12 @@
+{
+  "alice": {
+    "tokenassettype": "token1",
+    "numunits": "10000",
+    "owner": "alice"
+  },
+  "bob": {
+    "tokenassettype": "token1",
+    "numunits": "8000",
+    "owner": "bob"
+  }
+}


### PR DESCRIPTION
1. A bug in simpleasset where it was never creating new wallets for users has been fixed.
2. Added command to add/register users to fabric-network who can be participate in asset exchange: `fabric-cli user add`.
3. Added command to initialise the bond/token networks: `fabric-cli configure asset add`.