### PR TITLE
Allow interopcc to run in K8s as external service

### DIFF
--- a/core/network/fabric-interop-cc/Dockerfile
+++ b/core/network/fabric-interop-cc/Dockerfile
@@ -1,0 +1,32 @@
+FROM golang:1.16 AS build
+
+RUN apt-get update && apt-get install unzip
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.12.1/protoc-3.12.1-linux-x86_64.zip
+RUN mkdir /opt/protoc
+RUN unzip protoc-3.12.1-linux-x86_64.zip -d /opt/protoc
+ENV PATH="/opt/protoc/bin:${PATH}"
+ENV PATH="${PATH}:${HOME}/go/bin"
+
+RUN go get github.com/golang/protobuf/protoc-gen-go
+
+COPY .  /fabric-interop-cc
+WORKDIR /fabric-interop-cc
+
+RUN ./scripts/build-protos.sh
+
+RUN cd /fabric-interop-cc/contracts/interop && go build -o interop
+
+# Production ready image
+# Pass the binary to the prod image
+FROM alpine:3.11 as prod
+
+RUN apk add libc6-compat \
+        libstdc++
+COPY --from=build /fabric-interop-cc/contracts/interop/interop /app/interop
+RUN chmod +x /app/interop
+RUN chown 1000 /app
+
+USER 1000
+
+WORKDIR /app
+CMD ./interop

--- a/core/network/fabric-interop-cc/Dockerfile
+++ b/core/network/fabric-interop-cc/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.16 AS build
 
 RUN apt-get update && apt-get install unzip
-RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.12.1/protoc-3.12.1-linux-x86_64.zip
+RUN curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.15.6/protoc-3.15.6-linux-x86_64.zip
 RUN mkdir /opt/protoc
-RUN unzip protoc-3.12.1-linux-x86_64.zip -d /opt/protoc
+RUN unzip protoc-3.15.6-linux-x86_64.zip -d /opt/protoc
 ENV PATH="/opt/protoc/bin:${PATH}"
 ENV PATH="${PATH}:${HOME}/go/bin"
 

--- a/core/network/fabric-interop-cc/contracts/interop/main.go
+++ b/core/network/fabric-interop-cc/contracts/interop/main.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/hyperledger/fabric-chaincode-go/shim"
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
 	log "github.com/sirupsen/logrus"
 )
@@ -71,7 +72,25 @@ func main() {
 		return
 	}
 
-	if err := chaincode.Start(); err != nil {
-		fmt.Printf("Error starting Interop chaincode: %s", err.Error())
+	_, ok := os.LookupEnv("EXTERNAL_SERVICE")
+	if ok {
+		server := &shim.ChaincodeServer{
+				CCID:    os.Getenv("CHAINCODE_CCID"),
+				Address: os.Getenv("CHAINCODE_ADDRESS"),
+				CC:      chaincode,
+				TLSProps: shim.TLSProperties{
+										Disabled: true,
+									},
+		}
+		// Start the chaincode external server
+		err = server.Start()
+	} else {
+		err = chaincode.Start()
 	}
+	if err != nil {
+		fmt.Printf("Error starting Interop chaincode: %s", err)
+	}
+
+
+
 }

--- a/core/network/fabric-interop-cc/makefile
+++ b/core/network/fabric-interop-cc/makefile
@@ -6,19 +6,19 @@ protos-local:
 	echo "Calling update-protos script"
 	./scripts/update-protos-local.sh
 	echo "Generating go from protos"
-	protoc --proto_path=protos --proto_path=fabric-protos --go_out=contracts/interop/protos-go --go_opt=paths=source_relative protos/common/query.proto protos/common/ack.proto protos/common/proofs.proto protos/common/state.proto protos/corda/view_data.proto protos/fabric/view_data.proto protos/common/access_control.proto protos/common/membership.proto protos/common/verification_policy.proto protos/common/interop_payload.proto protos/common/asset_locks.proto
+	./scripts/build-protos.sh
 	cp -r contracts/interop/protos-go interfaces/asset-mgmt/
 
 protos:
 	echo "Calling update-protos script"
 	./scripts/update-protos.sh
 	echo "Generating go from protos"
-	protoc --proto_path=protos --proto_path=fabric-protos --go_out=contracts/interop/protos-go --go_opt=paths=source_relative protos/common/query.proto protos/common/ack.proto protos/common/proofs.proto protos/common/state.proto protos/corda/view_data.proto protos/fabric/view_data.proto protos/common/access_control.proto protos/common/membership.proto protos/common/verification_policy.proto protos/common/interop_payload.proto protos/common/asset_locks.proto
+	./scripts/build-protos.sh
 	cp -r contracts/interop/protos-go interfaces/asset-mgmt/
-	
+
 build:
 	echo "Building chaincode binary"
 	./scripts/build.sh
-	
+
 clean:
 	rm -rf ./bin

--- a/core/network/fabric-interop-cc/scripts/build-protos.sh
+++ b/core/network/fabric-interop-cc/scripts/build-protos.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+protoc --proto_path=protos --proto_path=fabric-protos --go_out=contracts/interop/protos-go --go_opt=paths=source_relative protos/common/query.proto protos/common/ack.proto protos/common/proofs.proto protos/common/state.proto protos/corda/view_data.proto protos/fabric/view_data.proto protos/common/access_control.proto protos/common/membership.proto protos/common/verification_policy.proto protos/common/interop_payload.proto protos/common/asset_locks.proto


### PR DESCRIPTION
1. Added Dockerfile to build the image for interopcc.
2. Also moved protos build command in a script, which can be called by makefile as well as Dockerfile.
