### PR TITLE
Code Fixes, and new command added to create all credentials for data transfer

### DIFF
--- a/sdks/fabric/interoperation-node-sdk/makefile
+++ b/sdks/fabric/interoperation-node-sdk/makefile
@@ -13,3 +13,6 @@ build:
 	npm install
 	npm run protos
 	npm run build
+
+clean:
+	rm -rf build node_modules package-lock.json

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/readme.md
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/readme.md
@@ -154,14 +154,14 @@ Example config:
 
   Sample `fabric-cli asset exchange-step` commands:
   ```
-  ./bin/fabric-cli asset exchange-step --step=1 --timeout-duration=3600 --locker=alice --recipient=bob --secret=secrettext --target-network=network1 --param=bond01:a03
+  ./bin/fabric-cli asset exchange-step --step=1 --timeout-duration=3600 --locker=alice --recipient=bob --secret=<hash-pre-image> --target-network=network1 --param=bond01:a03
  ./bin/fabric-cli asset exchange-step --step=2 --locker=alice --recipient=bob --target-network=network1 --param=bond01:a03
- ./bin/fabric-cli asset exchange-step --step=3 --timeout-duration=1800 --locker=bob --recipient=alice --hash=ivHErp1x4bJDKuRo6L5bApO/DdoyD/dG0mAZrzLZEIs= --target-network=network2 --param=token1:100
- ./bin/fabric-cli asset exchange-step --step=4 --locker=bob --recipient=alice --target-network=network2 --contract-id=D9soM+VZDfXT2mQYk1D8/+1OaXBBfCs1XzaN/xp90fU=
- ./bin/fabric-cli asset exchange-step --step=5 --recipient=alice --locker=bob --target-network=network2 --contract-id=D9soM+VZDfXT2mQYk1D8/+1OaXBBfCs1XzaN/xp90fU= --secret=secrettext
- ./bin/fabric-cli asset exchange-step --step=6 --recipient=bob --locker=alice --target-network=network1 --param=bond01:a03 --secret=secrettext
+ ./bin/fabric-cli asset exchange-step --step=3 --timeout-duration=1800 --locker=bob --recipient=alice --hash=<hash-value> --target-network=network2 --param=token1:100
+ ./bin/fabric-cli asset exchange-step --step=4 --locker=bob --recipient=alice --target-network=network2 --contract-id=<contract-id>
+ ./bin/fabric-cli asset exchange-step --step=5 --recipient=alice --locker=bob --target-network=network2 --contract-id=<contract-id> --secret=<hash-pre-image>
+ ./bin/fabric-cli asset exchange-step --step=6 --recipient=bob --locker=alice --target-network=network1 --param=bond01:a03 --secret=<hash-pre-image>
  ./bin/fabric-cli asset exchange-step --step=7 --locker=bob --recipient=alice --target-network=network1 --param=bond01:a03
- ./bin/fabric-cli asset exchange-step --step=8 --locker=bob --recipient=alice --target-network=network2 --contract-id=ww0k/40/73t4sNoVD/pebkW7UaQe18yE9aeiZCySxWo=
+ ./bin/fabric-cli asset exchange-step --step=8 --locker=bob --recipient=alice --target-network=network2 --contract-id=<contract-id>
  ```
 
 ## NOTE

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/readme.md
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/readme.md
@@ -3,34 +3,34 @@
 
  SPDX-License-Identifier: CC-BY-4.0
  -->
-# fabric-cli 
+# fabric-cli
 
 A CLI for interacting with the fabric test-net and relays. Made using [gluegun.js](https://infinitered.github.io/gluegun/#/)
 
-fabric-cli options: 
+fabric-cli options:
 
 ![cli options](./cli-options.png)
 
---help can be called on every command and provides examples and usage. 
+--help can be called on every command and provides examples and usage.
 
 More documentation can be found [here](docs/commands.md)
 
-# Folder Structure 
+# Folder Structure
     .
-    ├── build                      # Compiled files 
-    ├── docs                       # Documentation files 
+    ├── build                      # Compiled files
+    ├── docs                       # Documentation files
     ├── src                        # Source files
     │   ├── commands               # Commands for the cli. Subcommands are in named folders
     │   ├── data                   # Data used across the commands, includes credentials for other networks and basic data to initialise the network with
     │    ├── helpers                # Helper functions that are used across the commands
-    │   └── wallet-${networkname}  # Wallets used by the CLI to connect with the fabric networks. 
+    │   └── wallet-${networkname}  # Wallets used by the CLI to connect with the fabric networks.
     └── ...
 
-Another naming convention made is inside the commands folder files suffixed with "`-helper`" are used to for the `--help` options for each command. 
+Another naming convention made is inside the commands folder files suffixed with "`-helper`" are used to for the `--help` options for each command.
 
 # Installation
 
-The tool can be installed via npm or manually. If no development is required it is recommended to install via npm. 
+The tool can be installed via npm or manually. If no development is required it is recommended to install via npm.
 
 ## Installing with npm
 
@@ -40,7 +40,7 @@ Add contents of the `.npmrc` to the `.npmrc` located at `~/.npmrc`, be careful n
 
 then run `npm install -g @res-dlt-interop/fabric-cli`
 
-NOTE: If installing this way it is required to set up the env and config through the cli using either `fabric-cli env set <key> <value>` or `fabric-cli env set-file <file-path>`. Refer to the `.env.template` and `config.json `to determine what values are needed. 
+NOTE: If installing this way it is required to set up the env and config through the cli using either `fabric-cli env set <key> <value>` or `fabric-cli env set-file <file-path>`. Refer to the `.env.template` and `config.json `to determine what values are needed.
 
 ## Installing manually
 
@@ -61,7 +61,7 @@ Set up `.npmrc` by copying across the `.npmrc.template` and updating the values.
 
 Have `yarn` installed and have Node >= 11.14.0 <= 16.0.0
 
-Run `yarn` to install dependencies. 
+Run `yarn` to install dependencies.
 
 ### Development
 
@@ -71,7 +71,7 @@ and
 
 `yarn link`
 
-Then run 
+Then run
 
 `$ fabric-cli`
 
@@ -90,7 +90,7 @@ Setting env is not required inside docker, as env variables are already declared
 * `fabric-cli configure all network1 network2`.
 
 
-## Example Invoke 
+## Example Invoke
 
 To record a key `test` with the value `teststate` via the `simplestate` contract deployed on the `mychannel` channel in `network1`, run:
 ```
@@ -103,7 +103,7 @@ $ fabric-cli chaincode query mychannel simplestate read '["test"]' --local-netwo
 
 NOTE: Use the `--help` flag with any command to view examples and usage.
 
-## Publishing CLI 
+## Publishing CLI
 
 Run `npm publish` will error if same version is already published. Will need the artifactory token, will error if same version is already published. Will need the artifactory token.
 
@@ -112,14 +112,14 @@ Run `npm publish` will error if same version is already published. Will need the
 1) Go to IBM artifactory (https://na.artifactory.swg-devops.com/artifactory/)
 2) Click on your email id on top right
 3) Generate/Copy the API key from profile, let's say it is - "ThisIsMyAPIKey"
-4) Run this command on your system - 
+4) Run this command on your system -
 	 curl --header 'X-JFrog-Art-Api: ThisIsMyAPIKey' https://na.artifactory.swg-devops.com/artifactory/api/npm/auth
 5) The above command will return you auth token along with auth settings and your email id from artifactory.
 6) Create a .npmrc file in the backend folder (from where you want to run npm install)
 7) Add this line to your .npmrc file,
 	 @res-dlt-interop:registry=https://na.artifactory.swg-devops.com/artifactory/api/npm/res-dlt-interop-npm-local/
 8) Add the output of curl to that file.
-9) Final .npmrc should look like this - 
+9) Final .npmrc should look like this -
    "@res-dlt-interop:registry=https://na.artifactory.swg-devops.com/artifactory/api/npm/res-dlt-interop-npm-local/
     _auth = <Auth-token>
     always-auth = true
@@ -127,14 +127,14 @@ Run `npm publish` will error if same version is already published. Will need the
 10) Run npm install to check if artifactory connection is working before testing/deployment.
 
 ## Environment Variables
-- `DEFAULT_CHANNEL` (OPTIONAL) The default channel used by the CLI when invoking chaincode on a network. 
-- `DEFAULT_CHAINCODE`(OPTIONAL) The default chaincode id used by the CLI when invoking chaincode on a network. 
-- `MEMBER_CREDENTIAL_FOLDER`(OPTIONAL) The folder where network configurations will be stored and pulled from when generating network config and loading the chaincode. 
-- `CONFIG_PATH`(OPTIONAL) Path to the configuration file used by the CLI when creating network credentials and communicating with the relays. 
+- `DEFAULT_CHANNEL` (OPTIONAL) The default channel used by the CLI when invoking chaincode on a network.
+- `DEFAULT_CHAINCODE`(OPTIONAL) The default chaincode id used by the CLI when invoking chaincode on a network.
+- `MEMBER_CREDENTIAL_FOLDER`(OPTIONAL) The folder where network configurations will be stored and pulled from when generating network config and loading the chaincode.
+- `CONFIG_PATH`(OPTIONAL) Path to the configuration file used by the CLI when creating network credentials and communicating with the relays.
 
 ## Configuration file (required)
 
-The configuration file is used by the CLI when generating credentials to communicate with the network as well as the endpoint used to communicate with the relay. Each network can specify a unique relay and connection profile. 
+The configuration file is used by the CLI when generating credentials to communicate with the network as well as the endpoint used to communicate with the relay. Each network can specify a unique relay and connection profile.
 
 Example config:
 ```
@@ -150,6 +150,20 @@ Example config:
 }
 ```
 
+## Asset Exchange
+
+  Sample `fabric-cli asset exchange-step` commands:
+  ```
+  ./bin/fabric-cli asset exchange-step --step=1 --timeout-duration=3600 --locker=alice --recipient=bob --secret=secrettext --target-network=network1 --param=bond01:a03
+ ./bin/fabric-cli asset exchange-step --step=2 --locker=alice --recipient=bob --target-network=network1 --param=bond01:a03
+ ./bin/fabric-cli asset exchange-step --step=3 --timeout-duration=1800 --locker=bob --recipient=alice --hash=ivHErp1x4bJDKuRo6L5bApO/DdoyD/dG0mAZrzLZEIs= --target-network=network2 --param=token1:100
+ ./bin/fabric-cli asset exchange-step --step=4 --locker=bob --recipient=alice --target-network=network2 --contract-id=D9soM+VZDfXT2mQYk1D8/+1OaXBBfCs1XzaN/xp90fU=
+ ./bin/fabric-cli asset exchange-step --step=5 --recipient=alice --locker=bob --target-network=network2 --contract-id=D9soM+VZDfXT2mQYk1D8/+1OaXBBfCs1XzaN/xp90fU= --secret=secrettext
+ ./bin/fabric-cli asset exchange-step --step=6 --recipient=bob --locker=alice --target-network=network1 --param=bond01:a03 --secret=secrettext
+ ./bin/fabric-cli asset exchange-step --step=7 --locker=bob --recipient=alice --target-network=network1 --param=bond01:a03
+ ./bin/fabric-cli asset exchange-step --step=8 --locker=bob --recipient=alice --target-network=network2 --contract-id=ww0k/40/73t4sNoVD/pebkW7UaQe18yE9aeiZCySxWo=
+ ```
+
 ## NOTE
 
 Due to how fabric works and the CA works once a wallet has been created with identities in the CA you can not create new wallet without fist revoking the original credentials. This can have some issues if you have deleted a wallet and are trying to recreate one.
@@ -158,4 +172,3 @@ Due to how fabric works and the CA works once a wallet has been created with ide
 # License
 
 MIT - see LICENSE
-

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-all.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-all.ts
@@ -272,6 +272,7 @@ const command: GluegunCommand = {
     await network2U2.gateway.disconnect()
 
     console.log('Gateways disconnected.')
+    process.exit()
   }
 }
 

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-all.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-all.ts
@@ -114,22 +114,18 @@ const command: GluegunCommand = {
     // console.log(user1, assetType, assetId)
     // console.log(user2, fungibleAssetType, fungibleAssetAmt)
 
-    const spinner = print.spin(`Asset Exchange:\n`)
-
     const net1Config = getNetworkConfig(options['network1'])
     const net2Config = getNetworkConfig(options['network2'])
     if (!net1Config.connProfilePath || !net1Config.channelName || !net1Config.chaincode) {
       print.error(
         `Please use a valid --network1. No valid environment found for ${options['network1']} `
       )
-      spinner.fail(`Error`)
       return
     }
     if (!net2Config.connProfilePath || !net2Config.channelName || !net2Config.chaincode) {
       print.error(
         `Please use a valid --network2. No valid environment found for ${options['network2']} `
       )
-      spinner.fail(`Error`)
       return
     }
 
@@ -183,6 +179,8 @@ const command: GluegunCommand = {
     // console.log(user1CertN2)
     // console.log(user2CertN1)
 
+    const spinner = print.spin(`Asset Exchange:\n`)
+
     var res
     var contractId
 
@@ -203,7 +201,7 @@ const command: GluegunCommand = {
     } catch(error) {
         print.error(`Could not Lock Asset in ${options['network1']}`)
         spinner.fail(`Error`)
-        return
+        process.exit()
     }
 
     try {
@@ -225,7 +223,7 @@ const command: GluegunCommand = {
         print.error(`Could not Lock Fungible Asset in ${options['network2']}`)
         res = await AssetManager.reclaimAssetInHTLC(network1U1.contract, assetType, assetId, user2CertN1);
         spinner.fail(`Error`)
-        return
+        process.exit()
     }
 
     try {
@@ -242,7 +240,7 @@ const command: GluegunCommand = {
         res = await AssetManager.reclaimFungibleAssetInHTLC(network2U2.contract, contractId);
         res = await AssetManager.reclaimAssetInHTLC(network1U1.contract, assetType, assetId, user2CertN1);
         spinner.fail(`Error`)
-        return
+        process.exit()
     }
 
 
@@ -262,7 +260,7 @@ const command: GluegunCommand = {
         res = await AssetManager.reclaimFungibleAssetInHTLC(network2U2.contract, contractId);
         res = await AssetManager.reclaimAssetInHTLC(network1U1.contract, assetType, assetId, user2CertN1);
         spinner.fail(`Error`)
-        return
+        process.exit()
     }
     spinner.succeed('Asset Exchange Complete.')
 

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-step.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-step.ts
@@ -247,13 +247,20 @@ const command: GluegunCommand = {
         spinner.fail(`Error`)
         return
       }
+      if (options['secret'] || !options['hash']) {
+        print.error(
+          `Please provide hash value, do not specify preimage for this step.`
+        )
+        spinner.fail(`Error`)
+        return
+      }
       try {
         spinner.info(`Trying Fungible Asset Lock: ${param1}, ${param2} by ${locker} for ${recipient}`)
         res = await AssetManager.createFungibleHTLC(networkL.contract,
                         param1,
                         param2,
                         recipientCert,
-                        secret,
+                        '',
                         hash_secret,
                         timeout,
                         null)
@@ -405,6 +412,8 @@ const command: GluegunCommand = {
     await networkR.gateway.disconnect()
 
     console.log('Gateways disconnected.')
+
+    process.exit()
   }
 }
 

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-step.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-step.ts
@@ -206,7 +206,7 @@ const command: GluegunCommand = {
         if (!res.result) {
           throw new Error()
         }
-        spinner.info(`Asset Locked: ${res.result}, preimage: ${res.preimage}`)
+        spinner.info(`Asset Locked: ${res.result}, preimage: ${res.preimage}, hashvalue: ${hash_secret}`)
       } catch(error) {
           print.error(`Could not Lock Asset in ${options['target-network']}`)
           spinner.fail(`Error`)

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-step.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/asset/exchange-step.ts
@@ -26,7 +26,7 @@ const command: GluegunCommand = {
         print,
         toolbox,
         `fabric-cli asset exchange-step --step=1 --target-network=network1 --secret=secrettext --timeout-duration=100 --locker=bob --recipient=alice --param=Type1:a04`,
-        'fabric-cli asset exchange-step --step=<1-8> --target-network=<network1|network2> --secret=<secret> --timeout-epoch=<timeout-epoch> --timeout-duration=<timeout-duration> --locker=<locker-userid> --recipient=<recipient-userid> --secret=<preimage> --contract-id=<contract-id> --param=<param>',
+        'fabric-cli asset exchange-step --step=<1-8> --target-network=<network1|network2> --secret=<secret> --hash=<hashvalue> --timeout-epoch=<timeout-epoch> --timeout-duration=<timeout-duration> --locker=<locker-userid> --recipient=<recipient-userid> --secret=<preimage> --contract-id=<contract-id> --param=<param>',
         [
           {
             name: '--step',
@@ -41,7 +41,12 @@ const command: GluegunCommand = {
           {
             name: '--secret',
             description:
-              'secret text to be used Asset owner to hash lock. (Required for step 5, 6)'
+              'secret text to be used by Asset owner to hash lock. (Required for step 5, 6)'
+          },
+          {
+            name: '--hash',
+            description:
+              'hash value in base64 to be used for HTLC. (use only one of secret or hash, do not use both options)'
           },
           {
             name: '--timeout-epoch',
@@ -114,6 +119,10 @@ const command: GluegunCommand = {
     {
       secret = options['secret']
       hash_secret = crypto.createHash('sha256').update(secret).digest('base64');
+    }
+    else if (options['hash'])
+    {
+      hash_secret = options['hash']
     }
 
     // Timeout

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/chaincode/query.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/chaincode/query.ts
@@ -21,7 +21,7 @@ const command: GluegunCommand = {
       commandHelp(
         print,
         toolbox,
-        `fabric-cli chaincode  invoke --local-network=network1 mychannel interop Read '["56612afd-6730-4206-b25e-6d5d592789d3"]'`,
+        `fabric-cli chaincode query --local-network=network1 mychannel interop Read '["56612afd-6730-4206-b25e-6d5d592789d3"]'`,
         'fabric-cli chaincode --local-network=<network1|network2> --user=<user-id> query <channel-name> <contract-name> <function-name> <args array>',
         [
           {

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/asset/add.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/asset/add.ts
@@ -97,6 +97,7 @@ const command: GluegunCommand = {
       ccType: options['type'],
       logger: logger
     })
+    process.exit()
   }
 }
 

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/create/all.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/create/all.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright IBM Corp. All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { GluegunCommand } from 'gluegun'
+import { commandHelp, getNetworkConfig } from '../../../helpers/helpers'
+import logger from '../../../helpers/logger'
+import * as path from 'path'
+import * as dotenv from 'dotenv'
+dotenv.config({ path: path.resolve(__dirname, '../../.env') })
+
+import {
+  generateAccessControl,
+  getCurrentNetworkCredentialPath,
+  generateVerificationPolicy,
+  generateMembership
+} from '../../../helpers/fabric-functions'
+
+const command: GluegunCommand = {
+  name: 'all',
+  description: 'Generates the access-control, membership, and verification-policy for the local network',
+  run: async toolbox => {
+    const {
+      print,
+      parameters: { options, array }
+    } = toolbox
+    if (options.help || options.h) {
+      commandHelp(
+        print,
+        toolbox,
+        'fabric-cli configure create all --local-network=network1',
+        'fabric-cli configure create all --local-network=<network1|network2>',
+        [
+          {
+            name: '--local-network',
+            description: 'Local network for command. <network1|network2>'
+          },
+          {
+            name: '--username',
+            description: 'User for interop.'
+          },
+          {
+            name: '--debug',
+            description:
+              'Shows debug logs when running. Disabled by default. To enable --debug=true'
+          }
+        ],
+        command,
+        ['configure', 'create']
+      )
+      return
+    }
+    if (options.debug === 'true') {
+      logger.level = 'debug'
+      logger.debug('Debugging is enabled')
+    }
+    const networkEnv = getNetworkConfig(options['local-network'])
+    logger.debug(`NetworkEnv: ${JSON.stringify(networkEnv)}`)
+    if (!networkEnv.relayEndpoint || !networkEnv.connProfilePath) {
+      print.error(
+        'Please use a valid --local-network. If valid network please check if your environment variables are configured properly'
+      )
+      return
+    }
+
+    // Access Control
+    logger.info(
+      `Generating ${options['local-network']} network with access control`
+    )
+    const username =
+      options.username || `User1@org1.${options['local-network']}.com`
+
+    let templatePath = path.resolve(
+          __dirname,
+          '../../../data/interop/accessControlTemplate.json'
+        )
+    logger.info(`Template path: ${templatePath}`)
+    await generateAccessControl(
+      process.env.DEFAULT_CHANNEL ? process.env.DEFAULT_CHANNEL : 'mychannel',
+      process.env.DEFAULT_CHAINCODE ? process.env.DEFAULT_CHAINCODE : 'interop',
+      networkEnv.connProfilePath,
+      options['local-network'],
+      templatePath,
+      username,
+      global.__DEFAULT_MSPID__,
+      logger
+    )
+    logger.info(
+      `Generated ${
+        options['local-network']
+      } access control at  ${getCurrentNetworkCredentialPath(
+        options['local-network']
+      )} `
+    )
+
+    // Membership
+    logger.info(`Generating membership for ${options['local-network']}`)
+    await generateMembership(
+      process.env.DEFAULT_CHANNEL ? process.env.DEFAULT_CHANNEL : 'mychannel',
+      process.env.DEFAULT_CHAINCODE ? process.env.DEFAULT_CHAINCODE : 'interop',
+      networkEnv.connProfilePath,
+      options['local-network']
+    )
+    logger.info(
+      `Generated ${
+        options['local-network']
+      } secuirty group at ${getCurrentNetworkCredentialPath(
+        options['local-network']
+      )} `
+    )
+
+    // Verification Policy
+    logger.info(
+      `Generating ${options['local-network']} network with verification policy`
+    )
+    templatePath = path.resolve(
+          __dirname,
+          '../../../data/interop/verifiCationPolicyTemplate.json'
+        )
+    logger.info(`Template path: ${templatePath}`)
+    await generateVerificationPolicy(
+      process.env.DEFAULT_CHANNEL ? process.env.DEFAULT_CHANNEL : 'mychannel',
+      process.env.DEFAULT_CHAINCODE ? process.env.DEFAULT_CHAINCODE : 'interop',
+      networkEnv.connProfilePath,
+      options['local-network'],
+      templatePath,
+      global.__DEFAULT_MSPID__,
+      logger
+    )
+    logger.info(
+      `Generated ${
+        options['local-network']
+      } verification policy at ${getCurrentNetworkCredentialPath(
+        options['local-network']
+      )} `
+    )
+    process.exit()
+  }
+}
+
+module.exports = command

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/create/all.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/create/all.ts
@@ -38,7 +38,7 @@ const command: GluegunCommand = {
             description: 'Local network for command. <network1|network2>'
           },
           {
-            name: '--username',
+            name: '--user',
             description: 'User for interop.'
           },
           {
@@ -64,6 +64,22 @@ const command: GluegunCommand = {
       )
       return
     }
+
+    // Membership
+    logger.info(`Generating membership for ${options['local-network']}`)
+    await generateMembership(
+      process.env.DEFAULT_CHANNEL ? process.env.DEFAULT_CHANNEL : 'mychannel',
+      process.env.DEFAULT_CHAINCODE ? process.env.DEFAULT_CHAINCODE : 'interop',
+      networkEnv.connProfilePath,
+      options['local-network']
+    )
+    logger.info(
+      `Generated ${
+        options['local-network']
+      } secuirty group at ${getCurrentNetworkCredentialPath(
+        options['local-network']
+      )} `
+    )
 
     // Access Control
     logger.info(
@@ -95,29 +111,13 @@ const command: GluegunCommand = {
       )} `
     )
 
-    // Membership
-    logger.info(`Generating membership for ${options['local-network']}`)
-    await generateMembership(
-      process.env.DEFAULT_CHANNEL ? process.env.DEFAULT_CHANNEL : 'mychannel',
-      process.env.DEFAULT_CHAINCODE ? process.env.DEFAULT_CHAINCODE : 'interop',
-      networkEnv.connProfilePath,
-      options['local-network']
-    )
-    logger.info(
-      `Generated ${
-        options['local-network']
-      } secuirty group at ${getCurrentNetworkCredentialPath(
-        options['local-network']
-      )} `
-    )
-
     // Verification Policy
     logger.info(
       `Generating ${options['local-network']} network with verification policy`
     )
     templatePath = path.resolve(
           __dirname,
-          '../../../data/interop/verifiCationPolicyTemplate.json'
+          '../../../data/interop/verificationPolicyTemplate.json'
         )
     logger.info(`Template path: ${templatePath}`)
     await generateVerificationPolicy(

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/create/verification-policy.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/create/verification-policy.ts
@@ -69,7 +69,7 @@ const command: GluegunCommand = {
       ? path.resolve(options.template)
       : path.resolve(
           __dirname,
-          '../../../data/interop/verifiCationPolicyTemplate.json'
+          '../../../data/interop/verificationPolicyTemplate.json'
         )
     logger.info(`Template path: ${templatePath}`)
     await generateVerificationPolicy(

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/network.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/configure/network.ts
@@ -48,6 +48,7 @@ const command: GluegunCommand = {
       logger.debug('Debugging is enabled')
     }
     await configureNetwork(options['local-network'], logger)
+    process.exit()
   }
 }
 

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/interop-helper.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/interop-helper.ts
@@ -66,6 +66,10 @@ const command: GluegunCommand = {
               'Additional key to be sent to chaincode (used to store result if usign Write)'
           },
           {
+            name: '--username',
+            description: 'User for interop.'
+          },
+          {
             name: '--debug',
             description:
               'Shows debug logs when running. Disabled by default. To enable --debug=true'
@@ -110,7 +114,7 @@ const command: GluegunCommand = {
       mspId: options.mspId,
       logger
     })
-    const username = `User1@org1.${networkName}.com`
+    const username = options.username || `User1@org1.${networkName}.com`
     const [keyCert, keyCertError] = await handlePromise(
       getKeyAndCertForRemoteRequestbyUserName(wallet, username)
     )

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/interop-helper.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/interop-helper.ts
@@ -66,7 +66,7 @@ const command: GluegunCommand = {
               'Additional key to be sent to chaincode (used to store result if usign Write)'
           },
           {
-            name: '--username',
+            name: '--user',
             description: 'User for interop.'
           },
           {

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/user/add.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/user/add.ts
@@ -22,8 +22,8 @@ const command: GluegunCommand = {
       commandHelp(
         print,
         toolbox,
-        `fabric-cli add user --target-network=network1--id=user --secret=userpw`,
-        `fabric-cli add user --target-network=<network-name> --id=<id> --secret=<secret>`,
+        `fabric-cli user add --target-network=network1 --id=user --secret=userpw`,
+        `fabric-cli user add --target-network=<network-name> --id=<id> --secret=<secret>`,
         [],
         command,
         ['user', 'add']

--- a/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/user/add.ts
+++ b/tests/network-setups/fabric/dev/scripts/fabric-cli/src/commands/user/add.ts
@@ -55,6 +55,7 @@ const command: GluegunCommand = {
                     userPwd,
                     true
                   )
+    process.exit()
   }
 }
 


### PR DESCRIPTION
1. Fixed code getting stuck at end of asset exchange commands.
2. Added sample commands in readme for exchange-step.
3. Added new command `fabric-cli configure create all` to create all credentials (access-control policy, verification policy, membership) and modified interop command to accept user as parameter, in order to remove dependency on using wallet present in repo.
4. Some Typo fixes.