### PR TITLE
Fixing import path bug in Fabric Interop CC libs/testutils

### DIFF
--- a/core/network/fabric-interop-cc/libs/testutils/setup.go
+++ b/core/network/fabric-interop-cc/libs/testutils/setup.go
@@ -12,7 +12,7 @@ package testutils
 import (
 	"os"
 
-	"github.com/hyperledger-labs/weaver-dlt-interoperability/core/network/fabric-interop-cc/libs/test/mocks"
+	"github.com/hyperledger-labs/weaver-dlt-interoperability/core/network/fabric-interop-cc/libs/testutils/mocks"
 	"github.com/hyperledger/fabric-chaincode-go/pkg/cid"
 	"github.com/hyperledger/fabric-chaincode-go/shim"
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"


### PR DESCRIPTION
Signed-off-by: VRamakrishna <vramakr2@in.ibm.com>