### PR TITLE
add command parameters to handle account address n addition to account index, add to customize network parameters

### DIFF
--- a/samples/besu/besu-cli/src/commands/asset/get-balance.ts
+++ b/samples/besu/besu-cli/src/commands/asset/get-balance.ts
@@ -17,7 +17,7 @@ const command: GluegunCommand = {
 				print,
 				toolbox,
 				`besu-cli asset get-balance --network=network1 --account=1`,
-				'besu-cli asset get-balance --network=<network1|network2> --account=<1|2>',
+				'besu-cli asset get-balance --network=<network1|network2> --account=<1|2> --account_address=<account-address> --network_port=<port> --network_host=<host>',
 				[
 					{
 						name: '--network',
@@ -29,6 +29,21 @@ const command: GluegunCommand = {
 						description:
 							'The index of the account from the list obtained through web3.eth.getAccounts(). For example, we can set Alice as accounts[1] and hence value of this parameter for Alice can be 1.'
 					},
+					{
+						name: '--account_address',
+						description:
+							'The address of the account. We can set this parameter if we want to use account address instead of account index '
+					},
+					{
+						name: '--network_host',
+						description:
+							'The network host. Default value is taken from config.json'
+					},
+					{
+						name: '--network_port',
+						description:
+							'The network port. Default value is taken from config.json'
+					}
 				],
 				command,
 				['asset', 'get-balance']
@@ -37,25 +52,43 @@ const command: GluegunCommand = {
 		}
 		print.info('Get account balance of tokens')
 		const networkConfig = getNetworkConfig(options.network)
-		const provider = new Web3.providers.HttpProvider('http://'+networkConfig.networkHost+':'+networkConfig.networkPort)
+
+        var networkPort = networkConfig.networkPort
+        if(options.network_port){
+            networkPort = options.network_port
+            console.log('Use network port : ', networkPort)
+    	}
+    	var networkHost = networkConfig.networkHost
+    	if(options.network_host){
+    	    networkHost = options.network_host
+    	    console.log('Use network host : ', networkHost)
+        }
+
+		const provider = new Web3.providers.HttpProvider('http://'+networkHost+':'+networkPort)
 		const web3N = new Web3(provider)
 		const accounts = await web3N.eth.getAccounts()
 
 		const tokenContract = await getContractInstance(provider, networkConfig.tokenContract).catch(function () {
 			console.log("Failed getting tokenContract!");
 		})
-	
-		if(!options.account){
+
+	   var accountAddress
+	    if(options.account){
+			accountAddress = accounts[options.account]
+		}
+		else if(options.account_address){
+		    accountAddress = '0x'+ options.account_address
+		}
+		else{
 			print.error('Account index not provided')
 			return
 		}
-		const accountAddress = accounts[options.account]
 
 		console.log('Parameters')
 		console.log('networkConfig', networkConfig)
 		console.log('Account', accountAddress)
 		var balance = await tokenContract.balanceOf(accountAddress)
-		console.log(`Account balance of accounts[${options.account}] in Network ${options.network}: ${balance.toString()}`)
+		console.log(`Account balance of ${accountAddress} in Network ${options.network}: ${balance.toString()}`)
 	}
 }
 

--- a/samples/besu/besu-cli/src/commands/asset/is-locked.ts
+++ b/samples/besu/besu-cli/src/commands/asset/is-locked.ts
@@ -17,7 +17,7 @@ const command: GluegunCommand = {
 				print,
 				toolbox,
 				`besu-cli asset is-locked --network=network1 --lock_contract_id=lockContractID`,
-				'besu-cli asset is-locked --network=<network1|network2> --lock_contract_id=<lockContractID>',
+				'besu-cli asset is-locked --network=<network1|network2> --lock_contract_id=<lockContractID>  --network_port=<port> --network_host=<host>',
 				[
 					{
 						name: '--network',
@@ -29,6 +29,16 @@ const command: GluegunCommand = {
 						description:
 							'The address / ID of the lock contract.'
 					},
+					{
+						name: '--network_host',
+						description:
+							'The network host. Default value is taken from config.json'
+					},
+					{
+						name: '--network_port',
+						description:
+							'The network port. Default value is taken from config.json'
+					}
 				],
 				command,
 				['asset', 'is-locked']
@@ -46,9 +56,20 @@ const command: GluegunCommand = {
 		console.log('Parameters')
 		console.log('networkConfig', networkConfig)
 		console.log('Lock Contract ID', lockContractId)
-		
-		const provider = new Web3.providers.HttpProvider('http://'+networkConfig.networkHost+':'+networkConfig.networkPort)
-		const web3N = new Web3(provider)
+
+        var networkPort = networkConfig.networkPort
+        if(options.network_port){
+            networkPort = options.network_port
+            console.log('Use network port : ', networkPort)
+    	}
+    	var networkHost = networkConfig.networkHost
+    	if(options.network_host){
+    	    networkHost = options.network_host
+    	    console.log('Use network host : ', networkHost)
+        }
+
+		const provider = new Web3.providers.HttpProvider('http://'+networkHost+':'+networkPort)
+        const web3N = new Web3(provider)
 		const interopContract = await getContractInstance(provider, networkConfig.interopContract)	
 		const accounts = await web3N.eth.getAccounts()
 		var sender = accounts[networkConfig.senderAccountIndex]

--- a/samples/besu/besu-cli/src/commands/asset/issue.ts
+++ b/samples/besu/besu-cli/src/commands/asset/issue.ts
@@ -16,7 +16,7 @@ const command: GluegunCommand = {
 				print,
 				toolbox,
 				`besu-cli asset issue --network=network1 --account=1 --amount=10`,
-				'besu-cli asset issue --network=<network1|network2> --account=<account-index> --amount=<issue-ammount>',
+				'besu-cli asset issue --network=<network1|network2> --account=<account-index> --account_address=<account-address> --contract_owner_address=<contract-owner-address>  --amount=<issue-amount> --network_port=<port> --network_host=<host> ' ,
 				[
 					{
 						name: '--network',
@@ -29,9 +29,28 @@ const command: GluegunCommand = {
 							'The index of the account from the list obtained through web3.eth.getAccounts(). For example, we can set Alice as accounts[1] and hence value of this parameter for Alice can be 1.'
 					},
 					{
+						name: '--account_address',
+						description:
+							'The address of the account. We can set this parameter if we want to use account address instead of account index '
+					},					{
+						name: '--contract_owner_address',
+						description:
+							'The address of the contract owner. The default value is accounts[0]  '
+					},
+					{
 						name: '--amount',
 						description:
 							'The amount to be added to the account specified on the network'
+					},
+					{
+						name: '--network_host',
+						description:
+							'The network host. Default value is taken from config.json'
+					},
+					{
+						name: '--network_port',
+						description:
+							'The network port. Default value is taken from config.json'
 					}
 				],
 				command,
@@ -46,34 +65,56 @@ const command: GluegunCommand = {
 		}
 		const networkConfig = getNetworkConfig(options.network)
 		console.log('networkConfig', networkConfig)
-	
-		const provider = new Web3.providers.HttpProvider('http://'+networkConfig.networkHost+':'+networkConfig.networkPort)
+
+        var networkPort = networkConfig.networkPort
+        if(options.network_port){
+            networkPort = options.network_port
+            console.log('Use network port : ', networkPort)
+    	}
+    	var networkHost = networkConfig.networkHost
+    	if(options.network_host){
+    	    networkHost = options.network_host
+    	    console.log('Use network host : ', networkHost)
+        }
+
+
+		const provider = new Web3.providers.HttpProvider('http://'+networkHost+':'+networkPort)
 		const web3N = new Web3(provider)
 		const tokenContract = await getContractInstance(provider, networkConfig.tokenContract).catch(function () {
 			console.log("Failed getting tokenContract!");
 		})
 		const accounts = await web3N.eth.getAccounts()
 
-		var accountIndex
-		const contractOwner = accounts[0]
+
+		var contractOwner = accounts[0]
+		if(options.contract_owner_address){
+        	contractOwner = '0x'+ options.contract_owner_address
+        }
+
+		var account
 		if(options.account){
-			accountIndex = options.account
+			account = accounts[options.account]
 		}
-		else{
-			accountIndex = networkConfig.senderAccountIndex
+		else if(options.account_address){
+		     account = '0x'+ options.account_address
+		}else{
+			account = accounts[networkConfig.senderAccountIndex]
 		}
+
 		if(!options.amount){
 			print.error('Amount not provided')
 			return
 		}
-	
+
+	    console.log(`Contract owner address is ${contractOwner} `)
+	    console.log(`Receiver address is ${account} `)
 		// Transfer from the contract owner to the account specified
-		await tokenContract.transfer(accounts[accountIndex], options.amount, {from: contractOwner}).catch(function () {
+		await tokenContract.transfer(account, options.amount, {from: contractOwner}).catch(function () {
 			console.log("tokenContract transfer threw an error; Probably the token supply is used up!");
 		})
 
-		var balance = await tokenContract.balanceOf(accounts[options.account])
-		console.log(`Account balance of accounts[${options.account}] in Network ${options.network}: ${balance.toString()}`)
+		var balance = await tokenContract.balanceOf(account)
+		console.log(`Account balance of ${account} in Network ${options.network}: ${balance.toString()}`)
 	}
 }
 

--- a/samples/besu/besu-cli/src/commands/asset/lock.ts
+++ b/samples/besu/besu-cli/src/commands/asset/lock.ts
@@ -18,7 +18,7 @@ const command: GluegunCommand = {
 				print,
 				toolbox,
 				`besu-cli asset lock --network=network1 --sender_account=1 --recipient_account=2 --amount=5 --timeout=1000`,
-				'besu-cli asset lock --network=<network1|network2> --sender_account=<1|2> --recipient_account=<2|1> --amount=<lock-amount> --timeout=<lock-duration-seconds> --hash_base64=<hashLock-optional-parameter>',
+				'besu-cli asset lock --network=<network1|network2> --sender_account=<1|2> --recipient_account=<2|1> --amount=<lock-amount> --timeout=<lock-duration-seconds> --hash_base64=<hashLock-optional-parameter> --recipient_account_address=<recipient-account-address> --sender_account_address=<sender-account-address>  --network_port=<port> --network_host=<host> ',
 				[
 					{
 						name: '--network',
@@ -31,9 +31,19 @@ const command: GluegunCommand = {
 							'The index of the account of the sender/owner of the asset from the list obtained through web3.eth.getAccounts(). For example, we can set Alice as accounts[1] and hence value of this parameter for Alice can be 1.'
 					},
 					{
+						name: '--sender_account_address',
+						description:
+							'The address of the sender account. We can set this parameter if we want to use account address instead of account index '
+					},
+					{
 						name: '--recipient_account',
 						description:
 							'The index of the account of the recipient of the asset from the list obtained through web3.eth.getAccounts(). For example, we can set Alice as accounts[1] and hence value of this parameter for Alice can be 1.'
+					},
+					{
+						name: '--recipient_account_address',
+						description:
+							'The address of the recipient account. We can set this parameter if we want to use account address instead of account index '
 					},
 					{
 						name: '--amount',
@@ -49,6 +59,16 @@ const command: GluegunCommand = {
 						name: '--hash_base64',
 						description:
 							'The hash value with which the asset will be locked i.e., providing its pre-image will enable unlocking the asset. This is an optional parameter. If not provided, we will generate a fresh hash pair with a randomly generated pre-image and output the corresponding pre-image.'
+					},
+					{
+						name: '--network_host',
+						description:
+							'The network host. Default value is taken from config.json'
+					},
+					{
+						name: '--network_port',
+						description:
+							'The network port. Default value is taken from config.json'
 					}
 				],
 				command,
@@ -64,7 +84,19 @@ const command: GluegunCommand = {
 			return
 		}
 		const networkConfig = getNetworkConfig(options.network)
-		const provider = new Web3.providers.HttpProvider('http://'+networkConfig.networkHost+':'+networkConfig.networkPort)
+
+        var networkPort = networkConfig.networkPort
+        if(options.network_port){
+            networkPort = options.network_port
+            console.log('Use network port : ', networkPort)
+    	}
+    	var networkHost = networkConfig.networkHost
+    	if(options.network_host){
+    	    networkHost = options.network_host
+    	    console.log('Use network host : ', networkHost)
+        }
+
+		const provider = new Web3.providers.HttpProvider('http://'+networkHost+':'+networkPort)
 		const web3N = new Web3(provider)
 		const interopContract = await getContractInstance(provider, networkConfig.interopContract).catch(function () {
 			console.log("Failed getting interopContract!");
@@ -84,6 +116,9 @@ const command: GluegunCommand = {
 		if(options.sender_account){
 			sender = accounts[options.sender_account]
 		}
+		else if(options.sender_account_address){
+		    sender = '0x'+ options.sender_account_address
+		}
 		else{
 			print.info('Sender account index not provided. Taking from networkConfig..')
 			sender = accounts[networkConfig.senderAccountIndex]
@@ -91,6 +126,9 @@ const command: GluegunCommand = {
 		var recipient
 		if(options.recipient_account){
 			recipient = accounts[options.recipient_account]
+		}
+		else if(options.recipient_account_address){
+		     recipient = '0x'+ options.recipient_account_address
 		}
 		else{
 			print.info('Recipient account index not provided. Taking from networkConfig..')

--- a/samples/besu/besu-cli/src/commands/asset/unlock.ts
+++ b/samples/besu/besu-cli/src/commands/asset/unlock.ts
@@ -17,7 +17,7 @@ const command: GluegunCommand = {
 				print,
 				toolbox,
 				`besu-cli asset unlock --network=network1 --lock_contract_id=lockContractID --sender_account=1`,
-				'besu-cli asset unlock --network=<network1|network2> --lock_contract_id=<lockContractID> --sender_account=<1|2>',
+				'besu-cli asset unlock --network=<network1|network2> --lock_contract_id=<lockContractID> --sender_account=<1|2> --sender_account_address=<sender-account-address>  --network_port=<port> --network_host=<host> ',
 				[
 					{
 						name: '--network',
@@ -33,6 +33,21 @@ const command: GluegunCommand = {
 						name: '--sender_account',
 						description:
 							'The index of the account of the sender of the asset from the list obtained through web3.eth.getAccounts(). For example, we can set Alice as accounts[1] and hence value of this parameter for Alice can be 1.'
+					},
+					{
+						name: '--sender_account_address',
+						description:
+							'The address of the sender account. We can set this parameter if we want to use account address instead of account index '
+					},
+					{
+						name: '--network_host',
+						description:
+							'The network host. Default value is taken from config.json'
+					},
+					{
+						name: '--network_port',
+						description:
+							'The network port. Default value is taken from config.json'
 					}
 				],
 				command,
@@ -48,7 +63,19 @@ const command: GluegunCommand = {
 			return
 		}
 		const networkConfig = getNetworkConfig(options.network)
-		const provider = new Web3.providers.HttpProvider('http://'+networkConfig.networkHost+':'+networkConfig.networkPort)
+
+        var networkPort = networkConfig.networkPort
+        if(options.network_port){
+            networkPort = options.network_port
+            console.log('Use network port : ', networkPort)
+    	}
+    	var networkHost = networkConfig.networkHost
+    	if(options.network_host){
+    	    networkHost = options.network_host
+    	    console.log('Use network host : ', networkHost)
+        }
+
+		const provider = new Web3.providers.HttpProvider('http://'+networkHost+':'+networkPort)
 		const web3N = new Web3(provider)
 		const interopContract = await getContractInstance(provider, networkConfig.interopContract).catch(function () {
 			console.log("Failed getting interopContract!");
@@ -63,6 +90,9 @@ const command: GluegunCommand = {
 		if(options.sender_account){
 			sender = accounts[options.sender_account]
 		}
+		else if(options.sender_account_address){
+		    sender = '0x'+ options.sender_account_address
+		}
 		else{
 			print.info('Sender account index not provided. Taking from networkConfig..')
 			sender = accounts[networkConfig.senderAccountIndex]
@@ -73,7 +103,7 @@ const command: GluegunCommand = {
 		}
 		const lockContractId = '0x' + options.lock_contract_id
 
-		console.log('Paramters')
+		console.log('Parameters')
 		console.log('networkConfig', networkConfig)
 		console.log('Sender', sender)
 		console.log('Lock Contract ID', lockContractId)


### PR DESCRIPTION
In besu test environment we used  multi ethsigner instead of one ethsigner  with multiple signers.
That's why   I added parameters  `network_port`  and `network_host `in command line, in order to specify the port/host if needed. 
Also I added the possibility to use the account address  instead of the account index.


