### PR TITLE
Added Fabric Node SDK Unit Tests

### DIFF
--- a/.github/workflows/test_asset-exchange-corda.yml
+++ b/.github/workflows/test_asset-exchange-corda.yml
@@ -250,7 +250,9 @@ jobs:
         
       # CORDA CLI
       - name: Build CLI
-        run: make build-cli
+        run: |
+            cp ../../../tests/network-setups/corda/github.properties .
+            make build-cli
         working-directory: samples/corda/corda-simple-application
         
       - name: Setup Corda CLI init

--- a/.github/workflows/test_go.yml
+++ b/.github/workflows/test_go.yml
@@ -72,7 +72,7 @@ jobs:
       working-directory: samples/fabric/simplestate
 
     - name: Test
-      run: make test
+      run: go test -v ./...
       working-directory: samples/fabric/simplestate
  
   test_simpleasset:

--- a/core/network/fabric-interop-cc/contracts/interop/Makefile
+++ b/core/network/fabric-interop-cc/contracts/interop/Makefile
@@ -7,7 +7,10 @@ build-local: run-vendor
 	go build -v .
 	
 test-local: run-vendor test
-	
+
+build: clean
+	go build -v .
+
 test:
 	go test -v .
 	

--- a/docs/docs/external/getting-started/interop/asset-exchange.md
+++ b/docs/docs/external/getting-started/interop/asset-exchange.md
@@ -11,7 +11,7 @@ pagination_next: external/getting-started/enabling-weaver-network/overview
  SPDX-License-Identifier: CC-BY-4.0
  -->
 
-This document lists sample ways in which you can exercise the asset-exchange interoperation protocol on the test network [launched earlier](../test-network/overview.md).
+This document lists sample ways in which you can exercise the asset-exchange interoperation protocol on the test network [launched earlier](external/getting-started/test-network/overview.md).
 
 For this scenario, you only need the networks to be running with the appropriate contracts deployed and the ledgers bootstrapped. You do not need to run relays and drivers. You can run the following combinations of exchanges (_other combinations of DLTs will be supported soon_).
 

--- a/docs/docs/external/getting-started/interop/asset-exchange.md
+++ b/docs/docs/external/getting-started/interop/asset-exchange.md
@@ -11,7 +11,7 @@ pagination_next: external/getting-started/enabling-weaver-network/overview
  SPDX-License-Identifier: CC-BY-4.0
  -->
 
-This document lists sample ways in which you can exercise the asset-exchange interoperation protocol on the test network [launched earlier](../test-network/overview).
+This document lists sample ways in which you can exercise the asset-exchange interoperation protocol on the test network [launched earlier](../test-network/overview.md).
 
 For this scenario, you only need the networks to be running with the appropriate contracts deployed and the ledgers bootstrapped. You do not need to run relays and drivers. You can run the following combinations of exchanges (_other combinations of DLTs will be supported soon_).
 

--- a/docs/docs/external/getting-started/interop/asset-transfer.md
+++ b/docs/docs/external/getting-started/interop/asset-transfer.md
@@ -11,7 +11,7 @@ pagination_next: external/getting-started/enabling-weaver-network/overview
  SPDX-License-Identifier: CC-BY-4.0
  -->
 
-This document lists sample ways in which you can exercise the asset-transfer interoperation protocol on the test network [launched earlier](../test-network/overview).
+This document lists sample ways in which you can exercise the asset-transfer interoperation protocol on the test network [launched earlier](../test-network/overview.md).
 
 Once the networks, relays, and drivers have been launched, and the ledgers bootstrapped, you can trigger the following interoperation flows corresponding to distinct asset-sharing combinations _other combinations of DLTs will be supported soon_):
 ## 1. Fabric with Fabric

--- a/docs/docs/external/getting-started/interop/asset-transfer.md
+++ b/docs/docs/external/getting-started/interop/asset-transfer.md
@@ -11,7 +11,7 @@ pagination_next: external/getting-started/enabling-weaver-network/overview
  SPDX-License-Identifier: CC-BY-4.0
  -->
 
-This document lists sample ways in which you can exercise the asset-transfer interoperation protocol on the test network [launched earlier](../test-network/overview.md).
+This document lists sample ways in which you can exercise the asset-transfer interoperation protocol on the test network [launched earlier](external/getting-started/test-network/overview.md).
 
 Once the networks, relays, and drivers have been launched, and the ledgers bootstrapped, you can trigger the following interoperation flows corresponding to distinct asset-sharing combinations _other combinations of DLTs will be supported soon_):
 ## 1. Fabric with Fabric

--- a/docs/docs/external/getting-started/interop/data-sharing.md
+++ b/docs/docs/external/getting-started/interop/data-sharing.md
@@ -11,7 +11,7 @@ pagination_next: external/getting-started/enabling-weaver-network/overview
  SPDX-License-Identifier: CC-BY-4.0
  -->
 
-This document lists sample ways in which you can exercise the data-sharing interoperation protocol on the test network [launched earlier](../test-network/overview.md).
+This document lists sample ways in which you can exercise the data-sharing interoperation protocol on the test network [launched earlier](external/getting-started/test-network/overview.md).
 
 Once the networks, relays, and drivers have been launched, and the ledgers bootstrapped, you can trigger four different interoperation flows corresponding to distinct data-sharing combinations as follows:
 1. **Corda to Corda**: Either Corda network requests state and proof from another Corda network

--- a/docs/docs/external/getting-started/interop/data-sharing.md
+++ b/docs/docs/external/getting-started/interop/data-sharing.md
@@ -11,7 +11,7 @@ pagination_next: external/getting-started/enabling-weaver-network/overview
  SPDX-License-Identifier: CC-BY-4.0
  -->
 
-This document lists sample ways in which you can exercise the data-sharing interoperation protocol on the test network [launched earlier](../test-network/overview).
+This document lists sample ways in which you can exercise the data-sharing interoperation protocol on the test network [launched earlier](../test-network/overview.md).
 
 Once the networks, relays, and drivers have been launched, and the ledgers bootstrapped, you can trigger four different interoperation flows corresponding to distinct data-sharing combinations as follows:
 1. **Corda to Corda**: Either Corda network requests state and proof from another Corda network

--- a/samples/fabric/simpleasset/Makefile
+++ b/samples/fabric/simpleasset/Makefile
@@ -6,10 +6,15 @@ run-vendor:
 
 build-local: run-vendor
 	go build -v .
-build:
+
+build: clean-vendor
 	go build -v .
+
 test:
 	go test -v .
-clean:
+
+clean-vendor:
 	rm -rf vendor
+
+clean: clean-vendor
 	rm simpleasset

--- a/samples/fabric/simpleassetandinterop/Makefile
+++ b/samples/fabric/simpleassetandinterop/Makefile
@@ -1,11 +1,3 @@
-build:
-	go build -v .
-test:
-	go test -v .
-clean:
-	rm -rf vendor
-	rm simpleassetandinterop || true
-	
 run-vendor:
 	go mod vendor
 	cp -r ../../../common/protos-go/* vendor/github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go/
@@ -14,3 +6,15 @@ run-vendor:
 
 build-local: run-vendor
 	go build -v .
+
+build: clean-vendor
+	go build -v .
+
+test:
+	go test -v .
+
+clean-vendor:
+	rm -rf vendor
+
+clean: clean-vendor
+	rm simpleassetandinterop || true

--- a/samples/fabric/simpleassettransfer/Makefile
+++ b/samples/fabric/simpleassettransfer/Makefile
@@ -1,11 +1,3 @@
-build:
-	go build -v .
-test:
-	go test -v .
-clean:
-	rm -rf vendor
-	rm simpleasset
-	
 run-vendor:
 	go mod vendor
 	cp -r ../../../common/protos-go/* vendor/github.com/hyperledger-labs/weaver-dlt-interoperability/common/protos-go/
@@ -15,7 +7,19 @@ run-vendor:
 
 build-local: run-vendor
 	go build -v .
+
+build: clean-vendor
+	go build -v .
 	
+test: clean-vendor
+	go test -v .
+
+clean-vendor:
+	rm -rf vendor
+
+clean: clean-vendor
+	rm simpleassettransfer
+
 test-local: run-vendor
 	go test -v .
 

--- a/samples/fabric/simplestatewithacl/Makefile
+++ b/samples/fabric/simplestatewithacl/Makefile
@@ -5,10 +5,14 @@ run-vendor:
 	
 build-local: run-vendor
 	go build -v .
+build: clean-vendor
+	go build -v .
 test-local: run-vendor
 	go test -v .
-test:
-	go mod tidy
+test: clean-vendor
 	go test -v .
-clean:
-	rm -rf mocks simplestate vendor
+
+clean-vendor:
+	rm -rf vendor
+clean: clean-vendor
+	rm -rf mocks simplestate

--- a/sdks/fabric/interoperation-node-sdk/package.json
+++ b/sdks/fabric/interoperation-node-sdk/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.1.3",
     "@grpc/proto-loader": "^0.6.13",
-    "@hyperledger-labs/weaver-protos-js": "^1.3.0",
+    "@hyperledger-labs/weaver-protos-js": "^1.3.1",
     "elliptic": "^6.2.3",
     "fabric-common": "^2.2.8",
     "fabric-network": "^2.2.8",

--- a/sdks/fabric/interoperation-node-sdk/package.json
+++ b/sdks/fabric/interoperation-node-sdk/package.json
@@ -27,8 +27,9 @@
     "npm": "^7.10.0"
   },
   "dependencies": {
-    "@hyperledger-labs/weaver-protos-js": "^1.3.0",
     "@grpc/grpc-js": "^1.1.3",
+    "@grpc/proto-loader": "^0.6.13",
+    "@hyperledger-labs/weaver-protos-js": "^1.3.0",
     "elliptic": "^6.2.3",
     "fabric-common": "^2.2.8",
     "fabric-network": "^2.2.8",

--- a/sdks/fabric/interoperation-node-sdk/src/InteroperableHelper.ts
+++ b/sdks/fabric/interoperation-node-sdk/src/InteroperableHelper.ts
@@ -427,8 +427,8 @@ const interopFlow = async (
         views.push(requestResponse.view);
         viewsSerializedBase64.push(Buffer.from(requestResponse.view.serializeBinary()).toString("base64"));
         computedAddresses.push(requestResponse.address);
-        const respData = getResponseDataFromView(requestResponse.view, keyCert.key.toBytes());
-        if (respData.contents) {
+        if (confidential) {
+            const respData = getResponseDataFromView(requestResponse.view, keyCert.key.toBytes());
             viewContentsBase64.push(respData.contents.toString("base64"));
         } else {
             viewContentsBase64.push("");

--- a/sdks/fabric/interoperation-node-sdk/src/Relay.ts
+++ b/sdks/fabric/interoperation-node-sdk/src/Relay.ts
@@ -104,6 +104,9 @@ class Relay {
                 if (error) {
                     throw new Error(`Request state error: ${error}`);
                 }
+                if (resp.getStatus() === common_ack_pb.Ack.STATUS.ERROR) {
+                    throw new Error(`Request state received negative Ack error: ${resp.getMessage()}`);
+                }
                 return resp.getRequestId();
             }
             throw new Error("Error with requeststate in NetworkClient");
@@ -142,8 +145,11 @@ class Relay {
             if (stateError) {
                 throw new Error(`State error: ${stateError}`);
             }
-            if (finalState.getError()) {
+            if (finalState.getStatus() === statePb.RequestState.STATUS.ERROR && finalState.getError()) {
                 throw new Error(`Error from view payload : ${finalState.getError()}`);
+            }
+            if (finalState.getStatus() === statePb.RequestState.STATUS.ERROR) {
+                throw new Error(`Error from view payload : UNKNOWN REASON}`);
             }
             return finalState;
         } catch (e) {
@@ -196,5 +202,6 @@ class Relay {
         return asJson ? state.toObject() : state;
     }
 }
+
 
 export { Relay };

--- a/sdks/fabric/interoperation-node-sdk/src/Relay.ts
+++ b/sdks/fabric/interoperation-node-sdk/src/Relay.ts
@@ -145,11 +145,13 @@ class Relay {
             if (stateError) {
                 throw new Error(`State error: ${stateError}`);
             }
-            if (finalState.getStatus() === statePb.RequestState.STATUS.ERROR && finalState.getError()) {
-                throw new Error(`Error from view payload : ${finalState.getError()}`);
-            }
             if (finalState.getStatus() === statePb.RequestState.STATUS.ERROR) {
-                throw new Error(`Error from view payload : UNKNOWN REASON}`);
+                if (finalState.getError()) {
+                    throw new Error(`Error from view payload : ${finalState.getError()}`);
+                }
+                else {
+                    throw new Error(`Error from view payload : UNKNOWN REASON}`);
+                }
             }
             return finalState;
         } catch (e) {

--- a/sdks/fabric/interoperation-node-sdk/test/AssetManager.js
+++ b/sdks/fabric/interoperation-node-sdk/test/AssetManager.js
@@ -72,7 +72,7 @@ describe("AssetManager", () => {
         let amcStub;
 
         beforeEach(() => {
-            amcStub = sinon.stub(amc, "submitTransaction").resolves(false);
+            amcStub = sinon.stub(amc, "submitTransaction").resolves("");
         });
 
         it("asset lock fails with invalid parameters", async () => {
@@ -109,6 +109,7 @@ describe("AssetManager", () => {
             const hashValue = "abcdef123456"
             const hash = new hashFunctions.SHA256()
             hash.setSerializedHashBase64(hashValue)
+            const contractId = "CONTRACT-1234";
             let expiryTimeSecs = Math.floor(Date.now()/1000) + 300;   // Convert epoch milliseconds to seconds and add 5 minutes
             let lockInfoStr = assetManager.createAssetLockInfoSerialized(hash, expiryTimeSecs);
             amcStub.withArgs("LockAsset", assetAgreementStr, lockInfoStr).resolves(true);

--- a/sdks/fabric/interoperation-node-sdk/test/AssetManager.js
+++ b/sdks/fabric/interoperation-node-sdk/test/AssetManager.js
@@ -72,7 +72,7 @@ describe("AssetManager", () => {
         let amcStub;
 
         beforeEach(() => {
-            amcStub = sinon.stub(amc, "submitTransaction").resolves("");
+            amcStub = sinon.stub(amc, "submitTransaction").resolves(false);
         });
 
         it("asset lock fails with invalid parameters", async () => {
@@ -109,7 +109,6 @@ describe("AssetManager", () => {
             const hashValue = "abcdef123456"
             const hash = new hashFunctions.SHA256()
             hash.setSerializedHashBase64(hashValue)
-            const contractId = "CONTRACT-1234";
             let expiryTimeSecs = Math.floor(Date.now()/1000) + 300;   // Convert epoch milliseconds to seconds and add 5 minutes
             let lockInfoStr = assetManager.createAssetLockInfoSerialized(hash, expiryTimeSecs);
             amcStub.withArgs("LockAsset", assetAgreementStr, lockInfoStr).resolves(true);

--- a/sdks/fabric/interoperation-node-sdk/test/InteroperableHelper.js
+++ b/sdks/fabric/interoperation-node-sdk/test/InteroperableHelper.js
@@ -333,9 +333,9 @@ describe("InteroperableHelper", () => {
         const viewAddresses = ["localhost:9080/network1/mychannel:simplestate:Read:Arcturus",
             "localhost:9080/network1/mychannel:simplestate:Read:Betelguese:1"];
             
-        const meta = new statePb.Meta()
-        meta.setProtocol(statePb.Meta.Protocol.FABRIC)
-        meta.setTimestamp(new Date().toISOString())
+        const meta = new statePb.Meta();
+        meta.setProtocol(statePb.Meta.Protocol.FABRIC);
+        meta.setTimestamp(new Date().toISOString());
         meta.setProofType('Notarization');
         meta.setSerializationFormat('STRING');
         
@@ -343,17 +343,17 @@ describe("InteroperableHelper", () => {
         view1.setMeta(meta);
         view1.setData(Buffer.from('1'));
         const relayResponse1 = new statePb.RequestState();
-        relayResponse1.setRequestId("ABC-123")
-        relayResponse1.setStatus(statePb.RequestState.COMPLETED)
-        relayResponse1.setView(view1)
+        relayResponse1.setRequestId("ABC-123");
+        relayResponse1.setStatus(statePb.RequestState.COMPLETED);
+        relayResponse1.setView(view1);
         
         const view2 = new statePb.View();
         view2.setMeta(meta);
         view2.setData(Buffer.from('2'));
         const relayResponse2 = new statePb.RequestState();
-        relayResponse2.setRequestId("ABC-124")
-        relayResponse2.setStatus(statePb.RequestState.COMPLETED)
-        relayResponse2.setView(view2)
+        relayResponse2.setRequestId("ABC-124");
+        relayResponse2.setStatus(statePb.RequestState.COMPLETED);
+        relayResponse2.setView(view2);
         
         const views64 = [Buffer.from(view1.serializeBinary()).toString("base64"), 
             Buffer.from(view2.serializeBinary()).toString("base64")]

--- a/sdks/fabric/interoperation-node-sdk/test/InteroperableHelper.js
+++ b/sdks/fabric/interoperation-node-sdk/test/InteroperableHelper.js
@@ -40,6 +40,9 @@ describe("InteroperableHelper", () => {
     const foreignNetworkId = "foreignNetworkId";
     const userName = "user_name";
     const localRelayEndpoint = "localhost:9081";
+    const viewAddresses = ["localhost:9080/network1/mychannel:simplestate:Read:Arcturus",
+        "localhost:9080/network1/mychannel:simplestate:Read:Betelguese:1"];
+    const wrongViewAddress = "localhost:9080/network1/mychannel:simplestate:ReadWrong:Arcturus";
 
     let wallet;
     let interopcc;
@@ -240,7 +243,7 @@ describe("InteroperableHelper", () => {
         it("validate policy syntax and attributes", async () => {
             const policyJSON = await getPolicyCriteriaForAddress(
                 interopcc,
-                "localhost:9080/network1/mychannel:simplestate:Read:Arcturus",
+                viewAddresses[0],
             );
             expect(policyJSON).to.be.an("array");
             expect(policyJSON.length).to.equal(1);
@@ -250,7 +253,7 @@ describe("InteroperableHelper", () => {
             // no match found
             let policyJSON = await getPolicyCriteriaForAddress(
                 interopcc,
-                "localhost:9080/network1/mychannel:simplestate:ReadWrong:Arcturus",
+                wrongViewAddress,
             );
             expect(policyJSON).to.equal(null);
             
@@ -258,10 +261,10 @@ describe("InteroperableHelper", () => {
             try {
                 policyJSON = await getPolicyCriteriaForAddress(
                     interopcc,
-                    "localhost:9080/network2/mychannel:simplestate:ReadWrong:Arcturus",
+                    wrongViewAddress,
                 );
             } catch(error) {
-                expect(error.toString()).to.equal('Error: Error during getPolicyCriteriaForAddress: Error: No verification policy for address localhost:9080/network2/mychannel:simplestate:ReadWrong:Arcturus');
+                expect(error.toString()).to.equal('Error: Error during getPolicyCriteriaForAddress: Error: No verification policy for address ' + wrongViewAddress);
             }
         });
     });
@@ -295,7 +298,7 @@ describe("InteroperableHelper", () => {
                     "interop",
                     "mychannel",
                     "Write",
-                    JSON.stringify(["w"], "localhost:9080/network1/mychannel:simplestate:Read:Arcturus"),
+                    JSON.stringify(["w"], viewAddresses[0]),
                 )
                 .resolves(true);
             const vpResult = JSON.stringify(vpJSON);
@@ -330,8 +333,6 @@ describe("InteroperableHelper", () => {
         const appFn = "Write";
         const appArgs = ["w", "value", "", ""];
         const argsIndices = [2, 3];
-        const viewAddresses = ["localhost:9080/network1/mychannel:simplestate:Read:Arcturus",
-            "localhost:9080/network1/mychannel:simplestate:Read:Betelguese:1"];
             
         const meta = new statePb.Meta();
         meta.setProtocol(statePb.Meta.Protocol.FABRIC);
@@ -473,7 +474,7 @@ describe("InteroperableHelper", () => {
                 contractName: appId
             };
             const remoteJSON = {
-                address: "localhost:9080/network1/mychannel:simplestate:ReadWrong:Arcturus",
+                address: wrongViewAddress,
                 Sign: true
             }
             const keyCert = await getKeyAndCertForRemoteRequestbyUserName(wallet, userName);
@@ -502,7 +503,7 @@ describe("InteroperableHelper", () => {
                 contractName: appId
             };
             const remoteJSON = {
-                address: "localhost:9080/network1/mychannel:simplestate:Read:Arcturus",
+                address: viewAddresses[0],
                 Sign: true
             }
             const keyCert = await getKeyAndCertForRemoteRequestbyUserName(wallet, userName);

--- a/sdks/fabric/interoperation-node-sdk/test/Relay.js
+++ b/sdks/fabric/interoperation-node-sdk/test/Relay.js
@@ -16,13 +16,21 @@ const chai = require("chai");
 const sinon = require("sinon");
 const sinonChai = require("sinon-chai");
 
+import statePb from "@hyperledger-labs/weaver-protos-js/common/state_pb";
+import ackPb from "@hyperledger-labs/weaver-protos-js/common/ack_pb";
+import networksGrpcPb from "@hyperledger-labs/weaver-protos-js/networks/networks_grpc_pb";
+import networksPb from "@hyperledger-labs/weaver-protos-js/networks/networks_pb";
+
 const { expect } = chai;
 chai.use(sinonChai);
 const { Relay } = RelayHelper;
-const expectThrowsAsync = async (method, errorMessage) => {
+var grpc = require('@grpc/grpc-js');
+var protoLoader = require('@grpc/proto-loader');
+
+const expectThrowsAsync = async (method, args, errorMessage) => {
     let error = null;
     try {
-        await method();
+        await method(...args);
     } catch (err) {
         error = err;
     }
@@ -31,6 +39,7 @@ const expectThrowsAsync = async (method, errorMessage) => {
         expect(error.message).to.equal(errorMessage);
     }
 };
+
 // TODO: Add more testing for relay, need a mock gRPC endpoint
 describe("Relay", () => {
     let revert;
@@ -102,5 +111,217 @@ describe("Relay", () => {
                 relay.ProcessRequest("address", "policy", "requestingNetwork", "cert", "sig", "nonce"),
             );
         });
+    });
+    
+    describe("#successful relay api calls", () => {
+        const relay = new Relay("localhost:9080");
+        // Sample Request Id
+        const requestId = "ABC-123"
+        // Prepare Sample View
+        const meta = new statePb.Meta();
+        meta.setProtocol(statePb.Meta.Protocol.FABRIC);
+        meta.setTimestamp(new Date().toISOString());
+        meta.setProofType('Notarization');
+        meta.setSerializationFormat('STRING');
+        const view = new statePb.View();
+        view.setMeta(meta);
+        view.setData(Buffer.from('1'));
+        
+        const ack = {
+            status: ackPb.Ack.STATUS.OK,
+            requestId: requestId,
+            message: ''
+        }
+
+        const relayResponse = {
+            requestId: '',
+            status: statePb.RequestState.STATUS.COMPLETED,
+            view: view.toObject()
+        }
+        
+        let relayServer;
+        before(() => {
+            relayServer = new grpc.Server();
+            var packageDefinition = protoLoader.loadSync(
+                'networks/networks.proto',
+                {
+                 includeDirs: [__dirname + '/../../../../common/protos']
+                });
+            var networksProto = grpc.loadPackageDefinition(packageDefinition);
+            relayServer.addService(networksProto.networks.networks.Network.service, {
+                getState: (call, callback) => {
+                    relayResponse.requestId = call.request.requestId;
+                    callback(null, relayResponse);
+                },
+                requestState: (_, callback) => {
+                    callback(null, ack);
+                }
+            });
+            relayServer.bindAsync('0.0.0.0:9080', grpc.ServerCredentials.createInsecure(), () => {
+                relayServer.start();
+            });
+        });
+        after(() => {
+            relayServer.forceShutdown()
+        });
+        it("successful send request", async () => {
+            const reqId = await relay.SendRequest("", "", "", "", "", "", "", "");
+            expect(reqId).to.equal(requestId);
+        });
+            
+        it("successful get request", async () => {
+            const res = await relay.GetRequest(requestId, false);
+            expect(res.getRequestId()).to.equal(requestId);
+            expect(res.getStatus()).to.equal(relayResponse.status);
+            expect(res.hasError()).to.equal(false);
+            expect(res.hasView()).to.equal(true);
+            expect(res.getView().getData_asB64()).to.equal(view.getData_asB64());
+            expect(JSON.stringify(res.getView().getMeta().toObject())).to.equal(JSON.stringify(view.getMeta().toObject()));
+        });
+        
+        it("successful process request", async () => {
+            const res = await relay.ProcessRequest("", "", "", "", "", "", "", "");
+            expect(res.getRequestId()).to.equal(requestId);
+            expect(res.getStatus()).to.equal(relayResponse.status);
+            expect(res.hasError()).to.equal(false);
+            expect(res.hasView()).to.equal(true);
+            expect(res.getView().getData_asB64()).to.equal(view.getData_asB64());
+            expect(JSON.stringify(res.getView().getMeta().toObject())).to.equal(JSON.stringify(view.getMeta().toObject()));
+        });
+    });
+    describe("#fail relay api calls 1", () => {
+        const relay = new Relay("localhost:9081");
+        
+        let relayServer;
+        before(() => {
+            relayServer = new grpc.Server();
+            var packageDefinition = protoLoader.loadSync(
+                'networks/networks.proto',
+                {
+                 includeDirs: [__dirname + '/../../../../common/protos']
+                });
+            var networksProto = grpc.loadPackageDefinition(packageDefinition);
+            relayServer.addService(networksProto.networks.networks.Network.service, {
+                getState: (call, callback) => {
+                    callback(new Error("mock error"), null);
+                },
+                requestState: (_, callback) => {
+                    callback(new Error("mock error"), null);
+                }
+            });
+            relayServer.bindAsync('0.0.0.0:9081', grpc.ServerCredentials.createInsecure(), () => {
+                relayServer.start();
+            });
+        });
+        after(() => {
+            relayServer.forceShutdown()
+        });
+        it("fail send request", async () => {
+            const expectedErrMsg = 'Error: Error with Network Client: Error: Request state error: Error: 2 UNKNOWN: mock error';
+            try {
+                const reqId = await relay.SendRequest("", "", "", "", "", "", "", "");
+                throw new Error('IllegalState');
+            } catch (error) {
+                expect(error.toString()).to.equal(expectedErrMsg)
+            }
+        });
+        
+        it("fail get request", async () => {
+            const expectedErrMsg = 'Error: Error: Error: 2 UNKNOWN: mock error';
+            try {
+                const reqId = await relay.GetRequest('', false);
+                throw new Error('IllegalState');
+            } catch (error) {
+                expect(error.toString()).to.equal(expectedErrMsg)
+            }
+        });
+            
+    });
+    describe("#fail relay api calls 2", () => {
+        const relay = new Relay("localhost:9082", 2000);
+        const requestId = "ABC-123"
+
+        const ack = {
+            status: ackPb.Ack.STATUS.ERROR,
+            requestId: requestId,
+            message: 'mock error'
+        }
+
+        const relayResponse = {
+            requestId: '',
+            status: statePb.RequestState.STATUS.ERROR,
+            error: 'mock error'
+        }
+        
+        let relayServer;
+        before(() => {
+            relayServer = new grpc.Server();
+            var packageDefinition = protoLoader.loadSync(
+                'networks/networks.proto',
+                {
+                 includeDirs: [__dirname + '/../../../../common/protos']
+                });
+            var networksProto = grpc.loadPackageDefinition(packageDefinition);
+            relayServer.addService(networksProto.networks.networks.Network.service, {
+                getState: (call, callback) => {
+                    relayResponse.requestId = call.request.requestId;
+                    callback(null, relayResponse);
+                },
+                requestState: (_, callback) => {
+                    callback(null, ack);
+                }
+            });
+            relayServer.bindAsync('0.0.0.0:9082', grpc.ServerCredentials.createInsecure(), () => {
+                relayServer.start();
+            });
+        });
+        after(() => {
+            relayServer.forceShutdown()
+        });
+        it("fail send request", async () => {
+            const expectedErrMsg = 'Error: Error with Network Client: Error: Request state received negative Ack error: ' + ack.message;
+            try {
+                const reqId = await relay.SendRequest("", "", "", "", "", "", "", "");
+                throw new Error('IllegalState');
+            } catch (error) {
+                expect(error.toString()).to.equal(expectedErrMsg)
+            }
+        });
+        
+        it("fail process request", async () => {
+            // SendRequest error
+            const expectedErrMsg = 'Error: Error: Request state error: Error: Error with Network Client: Error: Request state received negative Ack error: ' + ack.message;
+            try {
+                const res = await relay.ProcessRequest("", "", "", "", "", "", "", "");
+                throw new Error('IllegalState');
+            } catch (error) {
+                expect(error.toString()).to.equal(expectedErrMsg)
+            }
+            
+            // GetState error
+            ack.status = ackPb.Ack.STATUS.OK;
+            ack.message = '';
+            const expectedErrMsg2 = 'Error: Error: Error from view payload : ' + relayResponse.error;
+            try {
+                const res = await relay.ProcessRequest("", "", "", "", "", "", "", "");
+                throw new Error('IllegalState');
+            } catch (error) {
+                expect(error.toString()).to.equal(expectedErrMsg2)
+            }
+        });
+            
+        it("fail pending state in process request", async () => {
+            // Pending till timeout
+            relayResponse.status = statePb.RequestState.STATUS.PENDING;
+            relayResponse.error = '';
+            const expectedErrMsg3 = 'Error: Error: State error: Error: Timeout: State is still pending.';
+            try {
+                const res = await relay.ProcessRequest("", "", "", "", "", "", "", "");
+                throw new Error('IllegalState');
+            } catch (error) {
+                expect(error.toString()).to.equal(expectedErrMsg3)
+            }
+        });
+            
     });
 });

--- a/sdks/fabric/interoperation-node-sdk/test/Relay.js
+++ b/sdks/fabric/interoperation-node-sdk/test/Relay.js
@@ -114,7 +114,8 @@ describe("Relay", () => {
     });
     
     describe("#successful relay api calls", () => {
-        const relay = new Relay("localhost:19080");
+        const localRelayEndpoint = "localhost:19080"
+        const relay = new Relay(localRelayEndpoint);
         // Sample Request Id
         const requestId = "ABC-123"
         // Prepare Sample View
@@ -157,7 +158,7 @@ describe("Relay", () => {
                     callback(null, ack);
                 }
             });
-            relayServer.bindAsync('0.0.0.0:19080', grpc.ServerCredentials.createInsecure(), () => {
+            relayServer.bindAsync(localRelayEndpoint, grpc.ServerCredentials.createInsecure(), () => {
                 relayServer.start();
             });
         });
@@ -190,7 +191,8 @@ describe("Relay", () => {
         });
     });
     describe("#fail relay api calls 1", () => {
-        const relay = new Relay("localhost:19081");
+        const localRelayEndpoint = "localhost:19081"
+        const relay = new Relay(localRelayEndpoint);
         
         let relayServer;
         before(() => {
@@ -209,7 +211,7 @@ describe("Relay", () => {
                     callback(new Error("mock error"), null);
                 }
             });
-            relayServer.bindAsync('0.0.0.0:19081', grpc.ServerCredentials.createInsecure(), () => {
+            relayServer.bindAsync(localRelayEndpoint, grpc.ServerCredentials.createInsecure(), () => {
                 relayServer.start();
             });
         });
@@ -238,7 +240,8 @@ describe("Relay", () => {
             
     });
     describe("#fail relay api calls 2", () => {
-        const relay = new Relay("localhost:19082", 2000);
+        const localRelayEndpoint = "localhost:19082"
+        const relay = new Relay(localRelayEndpoint, 2000);
         const requestId = "ABC-123"
 
         const ack = {
@@ -271,7 +274,7 @@ describe("Relay", () => {
                     callback(null, ack);
                 }
             });
-            relayServer.bindAsync('0.0.0.0:19082', grpc.ServerCredentials.createInsecure(), () => {
+            relayServer.bindAsync(localRelayEndpoint, grpc.ServerCredentials.createInsecure(), () => {
                 relayServer.start();
             });
         });

--- a/sdks/fabric/interoperation-node-sdk/test/Relay.js
+++ b/sdks/fabric/interoperation-node-sdk/test/Relay.js
@@ -114,7 +114,7 @@ describe("Relay", () => {
     });
     
     describe("#successful relay api calls", () => {
-        const relay = new Relay("localhost:9080");
+        const relay = new Relay("localhost:19080");
         // Sample Request Id
         const requestId = "ABC-123"
         // Prepare Sample View
@@ -157,7 +157,7 @@ describe("Relay", () => {
                     callback(null, ack);
                 }
             });
-            relayServer.bindAsync('0.0.0.0:9080', grpc.ServerCredentials.createInsecure(), () => {
+            relayServer.bindAsync('0.0.0.0:19080', grpc.ServerCredentials.createInsecure(), () => {
                 relayServer.start();
             });
         });
@@ -190,7 +190,7 @@ describe("Relay", () => {
         });
     });
     describe("#fail relay api calls 1", () => {
-        const relay = new Relay("localhost:9081");
+        const relay = new Relay("localhost:19081");
         
         let relayServer;
         before(() => {
@@ -209,7 +209,7 @@ describe("Relay", () => {
                     callback(new Error("mock error"), null);
                 }
             });
-            relayServer.bindAsync('0.0.0.0:9081', grpc.ServerCredentials.createInsecure(), () => {
+            relayServer.bindAsync('0.0.0.0:19081', grpc.ServerCredentials.createInsecure(), () => {
                 relayServer.start();
             });
         });
@@ -238,7 +238,7 @@ describe("Relay", () => {
             
     });
     describe("#fail relay api calls 2", () => {
-        const relay = new Relay("localhost:9082", 2000);
+        const relay = new Relay("localhost:19082", 2000);
         const requestId = "ABC-123"
 
         const ack = {
@@ -271,7 +271,7 @@ describe("Relay", () => {
                     callback(null, ack);
                 }
             });
-            relayServer.bindAsync('0.0.0.0:9082', grpc.ServerCredentials.createInsecure(), () => {
+            relayServer.bindAsync('0.0.0.0:19082', grpc.ServerCredentials.createInsecure(), () => {
                 relayServer.start();
             });
         });


### PR DESCRIPTION
1. Added Fabric Node SDK unit tests for Interoperable Helper and Relay.
2. Fixed docs links.
3. Fixed bug in house-token exchange corda workflow.
4. Adding clean vendor before building go chaincodes.

Closes #280 #246 