### PR TITLE
SDK Fix

### DIFF
--- a/sdks/fabric/interoperation-node-sdk/package.json
+++ b/sdks/fabric/interoperation-node-sdk/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.1.3",
     "@grpc/proto-loader": "^0.6.13",
-    "@hyperledger-labs/weaver-protos-js": "~1.5.0",
+    "@hyperledger-labs/weaver-protos-js": "~1.5.7",
     "elliptic": "^6.2.3",
     "fabric-common": "^2.2.8",
     "fabric-network": "^2.2.8",

--- a/sdks/fabric/interoperation-node-sdk/src/InteroperableHelper.ts
+++ b/sdks/fabric/interoperation-node-sdk/src/InteroperableHelper.ts
@@ -451,9 +451,9 @@ const verifyView = async (contract: Contract, base64ViewProto: string, address: 
 /**
  * Verifies a view's contents and extracts confidential payload by using chaincode function in interop chaincode. Verification is based on verification policy of the network, proof type and protocol type.
  **/
-const parseAndValidateView = async (contract: Contract, address: string, base64ViewProto: string, b64ViewContent: string): Promise<Buffer> => {
+const parseAndValidateView = async (contract: Contract, address: string, base64ViewProto: string, b64ViewContents: Array<string>): Promise<Buffer> => {
     try {
-        const viewPayload = await contract.evaluateTransaction("ParseAndValidateView", address, base64ViewProto, b64ViewContent);
+        const viewPayload = await contract.evaluateTransaction("ParseAndValidateView", address, base64ViewProto, JSON.stringify(b64ViewContents));
         return viewPayload;
     } catch (e) {
         throw new Error(`Unable to parse and validate view: ${e}`);


### PR DESCRIPTION
1. Update `parseAndValidateView` function in SDK to accept array of decoded payload contents, one from each node.

(Package already published on existing version)