### PR TITLE
Bug Fix in Interop Node SDK

### DIFF
--- a/sdks/fabric/interoperation-node-sdk/package-local.json
+++ b/sdks/fabric/interoperation-node-sdk/package-local.json
@@ -6,7 +6,7 @@
     "blockchain",
     "interoperability"
   ],
-  "version": "1.5.9",
+  "version": "1.5.10",
   "author": "V. Ramakrishna",
   "tag": "latest",
   "main": "build/index.js",

--- a/sdks/fabric/interoperation-node-sdk/package.json
+++ b/sdks/fabric/interoperation-node-sdk/package.json
@@ -6,7 +6,7 @@
     "blockchain",
     "interoperability"
   ],
-  "version": "1.5.9",
+  "version": "1.5.10",
   "author": "V. Ramakrishna",
   "tag": "latest",
   "main": "build/index.js",

--- a/sdks/fabric/interoperation-node-sdk/src/EventsManager.ts
+++ b/sdks/fabric/interoperation-node-sdk/src/EventsManager.ts
@@ -255,13 +255,14 @@ const getSubscriptionStatus = async (
 
     let eventSubscriptionState: eventsPb.EventSubscriptionState = relayResponse;
     for (const eventPubSpec of eventSubscriptionState.getEventPublicationSpecsList()) {
-        let ccArgsBytes = eventPubSpec.getCtx().getArgsList();
-        let ccArgsStr = [];
-        for (const ccArgBytes of ccArgsBytes) {
-            ccArgsStr.push(Buffer.from(ccArgBytes).toString('utf8'));
+        if (eventPubSpec.hasCtx()) {
+            let ccArgsBytes = eventPubSpec.getCtx().getArgsList();
+            let ccArgsStr = [];
+            for (const ccArgBytes of ccArgsBytes) {
+                ccArgsStr.push(Buffer.from(ccArgBytes).toString('utf8'));
+            }
+            eventPubSpec.getCtx().setArgsList(ccArgsStr);
         }
-
-        eventPubSpec.getCtx().setArgsList(ccArgsStr);
     }
 
     logger.debug(`Get event subscription status response: ${JSON.stringify(relayResponse)}`)


### PR DESCRIPTION
**BUG**: There's a bug in `GetSubscriptionState` in Weaver Fabric SDK, which doesn't work when `ContractTransaction` is not present in `EventPublicationSpec`, i.e. when `appURL` is used for subscription, as there's few lines of code which only works with `ContractTransaction` in event publication spec.

**FIX**: Added a safety check `EventPublicationSpec.hasCtx()` around the code to fix it, which checks if the `EventSubscription` has `ContractTransaction` then only it executes the code.