### PR TITLE
fix: deploy go fabric-weaver-cc image to fix go version

### DIFF
--- a/.github/workflows/deploy_go-pkgs.yml
+++ b/.github/workflows/deploy_go-pkgs.yml
@@ -342,6 +342,11 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v4.1.1
       
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.20.2'
+      
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
Go 1.21+ requires changes in `go.mod`, hence for now fixing go version in workflows to be `1.20`.